### PR TITLE
avoid download for wow files

### DIFF
--- a/plugins/nf-cws/src/main/nextflow/cws/k8s/CWSK8sExecutor.groovy
+++ b/plugins/nf-cws/src/main/nextflow/cws/k8s/CWSK8sExecutor.groovy
@@ -24,6 +24,7 @@ import nextflow.util.Duration
 import nextflow.util.ServiceName
 import org.pf4j.ExtensionPoint
 
+import java.nio.file.Path
 import java.nio.file.Paths
 
 @Slf4j
@@ -296,4 +297,9 @@ class CWSK8sExecutor extends K8sExecutor implements ExtensionPoint {
 
     }
 
+    @Override
+    boolean isForeignFile( Path path ) {
+        if ( path.getScheme() == 'wow' ) return false
+        return super.isForeignFile(path)
+    }
 }


### PR DESCRIPTION
It seems that all stagings are generated here:
https://github.com/ftschirpke/nextflow/blob/master/modules/nextflow/src/main/groovy/nextflow/processor/TaskProcessor.groovy#L2185
Therefore, I overwrite the isForeignFile in the CWSK8sExecutor.